### PR TITLE
Use Aeson.toEncoding

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,10 +87,12 @@ Previously we defined our data with `deriving (Generic)` utilizing the `DeriveGe
 
 ~~~ {.haskell}
 instance Aeson.FromJSON A
-instance Aeson.ToJSON A
+instance Aeson.ToJSON A where
+  toEncoding = Aeson.genericToEncoding Aeson.defaultOptions
 
 instance Aeson.FromJSON B
-instance Aeson.ToJSON B
+instance Aeson.ToJSON B where
+  toEncoding = Aeson.genericToEncoding Aeson.defaultOptions
 ~~~
 
 Luckily `Data.MessagePack` does too.


### PR DESCRIPTION
I recently worked on a project where we evaluated and benchmarked both MsgPack and Aeson. For *encoding*, Aeson turned out to be about a factor two faster than MsgPack. This is because Aeson can encode directly to a byte string, it does not have to build up an intermediate object first, and then encode that to a byte string. But by default it does do that, you explicitly have to provide a `toEncoding` implementation.

This makes Aeson faster in the benchmark.